### PR TITLE
CLI Rewrite & Integration with retoc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,10 @@ jobs:
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
             echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           fi
+      - uses: swatinem/rust-cache@v2
+        with:
+          key: ${{ join(matrix.targets, '-') }}
+          cache-provider: ${{ matrix.cache_provider }}
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -10,7 +10,7 @@ ci = "github"
 # The installers to generate for each app
 installers = ["shell"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
+targets = ["x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
 # Which actions to run on pull requests
 pr-run-mode = "upload"
 # Path that installers should place binaries in

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -10,11 +10,11 @@ ci = "github"
 # The installers to generate for each app
 installers = ["shell"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+targets = ["x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
 # Which actions to run on pull requests
-pr-run-mode = "plan"
+pr-run-mode = "upload"
 # Path that installers should place binaries in
 install-path = "CARGO_HOME"
 # Whether to install an updater program
-install-updater = false
+install-updater = true
 # Whether to install an updater program


### PR DESCRIPTION
This PR aims to rewrite the existing CLI, driven by the need to integrate functionality from an additional tool (`retoc`, also a CLI). The end goal is to merge both tools into a unified interface, while restructuring `retoc_cli` into a reusable library in a cleaner state than it is on the main branch alongside corresponding changes to the GUI to accommodate the new design of retoc. 

### Goals:
- [x] Remove legacy CLI implementation
- [ ] Implement skeleton CLI framework
- [ ] Refactor `retoc` into a reusable library
- [ ] Integrate `retoc` functionality into the new unified CLI
- [ ] Redesign CLI commands and flags for unified behavior
- [ ] Add automatic detection for IOStore vs legacy pakfiles in CLI
- [ ] Update GUI to interface with the refactored `retoc` library
- [ ] Perform full end-to-end testing (CLI + GUI)
- [ ] Finalize cleanup and write documentation
- [ ] Provide Bash and Batch scripts that wrap the new CLI
