### PR TITLE
add flake.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,117 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1772560058,
+        "narHash": "sha256-NuVKdMBJldwUXgghYpzIWJdfeB7ccsu1CC7B+NfSoZ8=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "db590d9286ed5ce22017541e36132eab4e8b3045",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1772694321,
+        "narHash": "sha256-nfKwfaD9brXQSxWEkXAEoDZZVhhHPP7A6CH5pLnY6kQ=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "6dfabfd5c569304182ca0b670c0d5765acbd1081",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flakelight": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1772457021,
+        "narHash": "sha256-TCVI5o3/v/fsLYZhwI7Jp52GVdNq4P/qiAP/B3ww7do=",
+        "owner": "nix-community",
+        "repo": "flakelight",
+        "rev": "c576dab67cdcdc28e81a85f5f1c9c5743742144e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "flakelight",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1772198003,
+        "narHash": "sha256-I45esRSssFtJ8p/gLHUZ1OUaaTaVLluNkABkk6arQwE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "dd9b079222d43e1943b6ebd802f04fd959dc8e61",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1772674223,
+        "narHash": "sha256-/suKbHSaSmuC9UY7G0VRQ3aO+QKqxAQPQ19wG7QNkF8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "66d9241e3dc2296726dc522e62dbfe89c7b449f3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "fenix": "fenix",
+        "flakelight": "flakelight",
+        "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1772640484,
+        "narHash": "sha256-uMTq51iQxRoogkJ3P2/Lh+75fR61W30OvqJALX80aoA=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "789ad511092976f94db03be7a9b447c64ed7ce7e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -44,14 +44,12 @@
             makeWrapper
           ];
 
-          env = {
-            LD_LIBRARY_PATH = "${pkgs.stdenv.cc.cc.lib}/lib"; # unsure if needed or not
-          };
+          buildInputs = [pkgs.stdenv.cc.cc.lib];
 
           # banger postInstall right here
           postInstall = ''
             wrapProgram $out/bin/repak-gui \
-              --prefix LD_LIBRARY_PATH : ${pkgs.stdenv.cc.cc.lib}/lib:${pkgs.libX11}/lib:${pkgs.libXcursor}/lib:${pkgs.libxi}/lib:${pkgs.libxkbcommon}/lib:${pkgs.mesa}/lib:${pkgs.libGL}/lib
+              --prefix LD_LIBRARY_PATH : ${with pkgs; lib.makeLibraryPath [stdenv.cc.cc.lib libX11 libXcursor libXcursor libxi libxkbcommon mesa libGL]}
           '';
         };
       apps.default = packages: {

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,72 @@
+{
+  inputs = {
+    self.submodules = true;
+    flakelight.url = "github:nix-community/flakelight";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    crane.url = "github:ipetkov/crane";
+
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = {
+    flakelight,
+    crane,
+    fenix,
+    ...
+  }:
+    flakelight ./. {
+      # make you able to access pkgs.fenix.complete.xyz
+      withOverlays = [
+        fenix.overlays.default
+      ];
+
+      packages.default = {pkgs, ...}: let
+        craneLib = (crane.mkLib pkgs).overrideToolchain (
+          p:
+            p.fenix.complete.withComponents [
+              "cargo"
+              "clippy"
+              "rust-src"
+              "rustc"
+              "rustfmt"
+            ]
+        );
+      in
+        craneLib.buildPackage {
+          pname = "repak-rivals"; # i added this so crane wont spam my fucking terminal
+          doCheck = false; # disable tests
+          src = ./.;
+          nativeBuildInputs = with pkgs; [
+            stdenv.cc.cc.lib
+            makeWrapper
+          ];
+
+          env = {
+            LD_LIBRARY_PATH = "${pkgs.stdenv.cc.cc.lib}/lib"; # unsure if needed or not
+          };
+
+          # banger postInstall right here
+          postInstall = ''
+            wrapProgram $out/bin/repak-gui \
+              --prefix LD_LIBRARY_PATH : ${pkgs.stdenv.cc.cc.lib}/lib:${pkgs.libX11}/lib:${pkgs.libXcursor}/lib:${pkgs.libxi}/lib:${pkgs.libxkbcommon}/lib:${pkgs.mesa}/lib:${pkgs.libGL}/lib
+          '';
+        };
+      apps.default = packages: {
+        type = "app";
+        program = "${packages.default}/bin/repak-gui";
+      };
+      devShell.packages = {pkgs, ...}: [
+        (pkgs.fenix.complete.withComponents [
+          "cargo"
+          "clippy"
+          "rust-src"
+          "rustc"
+          "rustfmt"
+          "rust-analyzer"
+        ])
+      ];
+    };
+}


### PR DESCRIPTION
this flake allow you to do the following
- be able to run repak-gui by simply run `nix run github:natimerry/repak-rivals`
- add devShell to make development environment ready (you can enter devShell by running `nix develop`)
- able to compile a program directly via `nix build`
- end user will be able to install this package by importing the inputs and add inputs.repak-rivals.packages.${system}.default (assuming they add the input name as repak-rivals)

idk what to say anymore man, tbh i dont think i even need crane but its so easy and pretty well documented compared to nixpkgs so i just use it