### PR TITLE
fix nix build

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1772560058,
-        "narHash": "sha256-NuVKdMBJldwUXgghYpzIWJdfeB7ccsu1CC7B+NfSoZ8=",
+        "lastModified": 1779130139,
+        "narHash": "sha256-BLrtr42azquO7MdGFU5a7KiMl3YpFlTeIXqy1fT5GlQ=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "db590d9286ed5ce22017541e36132eab4e8b3045",
+        "rev": "edb38893982a3338972bb4a2ec7ce7c29ba10fd9",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1772694321,
-        "narHash": "sha256-nfKwfaD9brXQSxWEkXAEoDZZVhhHPP7A6CH5pLnY6kQ=",
+        "lastModified": 1779790483,
+        "narHash": "sha256-2wCMtmVmkCcyHaH6hkrbx7XdUgLYP5E1wl/jc1YxxTY=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "6dfabfd5c569304182ca0b670c0d5765acbd1081",
+        "rev": "6012e5463531342033571efe294ec880bf13dd95",
         "type": "github"
       },
       "original": {
@@ -41,11 +41,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1772457021,
-        "narHash": "sha256-TCVI5o3/v/fsLYZhwI7Jp52GVdNq4P/qiAP/B3ww7do=",
+        "lastModified": 1779722240,
+        "narHash": "sha256-cX1d9V5JHTytsSdH8RrgyU4fFdm4oooRuKBcJuiyI4U=",
         "owner": "nix-community",
         "repo": "flakelight",
-        "rev": "c576dab67cdcdc28e81a85f5f1c9c5743742144e",
+        "rev": "6908ac68dd682d1cb22fdb9391b890798f083a48",
         "type": "github"
       },
       "original": {
@@ -56,11 +56,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772198003,
-        "narHash": "sha256-I45esRSssFtJ8p/gLHUZ1OUaaTaVLluNkABkk6arQwE=",
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dd9b079222d43e1943b6ebd802f04fd959dc8e61",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
         "type": "github"
       },
       "original": {
@@ -72,11 +72,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1772674223,
-        "narHash": "sha256-/suKbHSaSmuC9UY7G0VRQ3aO+QKqxAQPQ19wG7QNkF8=",
+        "lastModified": 1779694939,
+        "narHash": "sha256-Ly4j75O8ICaSQx3uxPnwk2x7PMF0XQvn5r0c3yBA7FI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "66d9241e3dc2296726dc522e62dbfe89c7b449f3",
+        "rev": "f9d8b65950353691ab56561e7c73d2e1063d810b",
         "type": "github"
       },
       "original": {
@@ -89,17 +89,17 @@
     "retoc-rivals": {
       "flake": false,
       "locked": {
-        "lastModified": 1760590922,
-        "narHash": "sha256-pYzuu4pxRPXYerHblB1ZjFrv5KAlkIMwKTzy7rX39s0=",
+        "lastModified": 1779630068,
+        "narHash": "sha256-Mk0eXXX2zIZUmBuoZsVIdQcEp/SAYlDK1h/KZSbJODM=",
         "owner": "natimerry",
         "repo": "retoc-rivals",
-        "rev": "c5b00c2b7b77ab5ac1fbf537bee02145e8a642e0",
+        "rev": "00a9468510902bfb078393718e484d6c5a66a1af",
         "type": "github"
       },
       "original": {
         "owner": "natimerry",
-        "ref": "c5b00c2",
         "repo": "retoc-rivals",
+        "rev": "00a9468510902bfb078393718e484d6c5a66a1af",
         "type": "github"
       }
     },
@@ -116,11 +116,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1772640484,
-        "narHash": "sha256-uMTq51iQxRoogkJ3P2/Lh+75fR61W30OvqJALX80aoA=",
+        "lastModified": 1779742949,
+        "narHash": "sha256-Dk0hnFTXbmNmigsJyQkCz2NEEgtpe+MN500dPnki9Ic=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "789ad511092976f94db03be7a9b447c64ed7ce7e",
+        "rev": "462d95ca60fa7360b44258be94105bc20e203684",
         "type": "github"
       },
       "original": {
@@ -133,17 +133,17 @@
     "uasset-mesh-patch-rivals": {
       "flake": false,
       "locked": {
-        "lastModified": 1740339544,
-        "narHash": "sha256-mwH1zmInTMDsGzpUWVx5Gxg9BqsiFLs6iVchsC+ClU4=",
+        "lastModified": 1779287736,
+        "narHash": "sha256-Z2z4WxAsDjgwsyKmskkMAG06bUlWq/4cZATI94ycIyw=",
         "owner": "natimerry",
         "repo": "uasset-mesh-patch-rivals",
-        "rev": "a9e9f339e0039f76e498455b1519375b336c6a32",
+        "rev": "93f78118b661dde469f41361a2ebf004eb4f4ca2",
         "type": "github"
       },
       "original": {
         "owner": "natimerry",
-        "ref": "a9e9f33",
         "repo": "uasset-mesh-patch-rivals",
+        "rev": "93f78118b661dde469f41361a2ebf004eb4f4ca2",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -10,11 +10,11 @@
     };
 
     retoc-rivals = {
-      url = "github:natimerry/retoc-rivals/c5b00c2";
+      url = "github:natimerry/retoc-rivals/00a9468510902bfb078393718e484d6c5a66a1af";
       flake = false;
     };
     uasset-mesh-patch-rivals = {
-      url = "github:natimerry/uasset-mesh-patch-rivals/a9e9f33";
+      url = "github:natimerry/uasset-mesh-patch-rivals/93f78118b661dde469f41361a2ebf004eb4f4ca2";
       flake = false;
     };
   };
@@ -34,7 +34,21 @@
         fenix.overlays.default
       ];
 
+      packages.uasset-api = {pkgs, ...}: pkgs.buildDotnetModule rec {
+        name = "UAssetAPI-Kawaii";
+        version = "95b4053";
+        src = pkgs.fetchFromGitHub {
+          owner = "natimerry";
+          repo = "UAssetAPI-Kawaii";
+          rev = version;
+          hash = "sha256-tee/HD2mPiCOfpLbbbFG6lo6tGfOSVXJVr1o0fWLxQY=";
+        };
+        dotnet-sdk = pkgs.dotnet-sdk_8;
+        nugetDeps = ./nix/deps.json;
+      };
+
       packages.default = {pkgs, ...}: let
+        UAssetAPI = self.packages.${pkgs.system}.uasset-api;
         craneLib = (crane.mkLib pkgs).overrideToolchain (
           p:
             p.fenix.complete.withComponents [
@@ -60,6 +74,7 @@
           inherit src;
           pname = "repak-rivals";
           doCheck = false;
+          NIX_UASSET_API_PATH = UAssetAPI;
         };
       in
         craneLib.buildPackage {
@@ -72,7 +87,10 @@
             makeWrapper
           ];
 
-          buildInputs = [pkgs.stdenv.cc.cc.lib];
+          buildInputs = [pkgs.stdenv.cc.cc.lib UAssetAPI];
+
+          NIX_UASSET_API_PATH = UAssetAPI;
+          patches = [ ./nix/retoc-build.patch ];
 
           # banger postInstall right here
           postInstall = ''
@@ -90,21 +108,37 @@
                   libGL
                 ]
             }
+
           '';
         };
       apps.default = packages: {
         type = "app";
         program = "${packages.default}/bin/repak-gui";
       };
-      devShell.packages = {pkgs, ...}: [
-        (pkgs.fenix.complete.withComponents [
-          "cargo"
-          "clippy"
-          "rust-src"
-          "rustc"
-          "rustfmt"
-          "rust-analyzer"
-        ])
-      ];
+      devShell = {pkgs, ...}: {
+        inputsFrom = [ self.packages.${pkgs.system}.default ];
+        packages = [
+          (pkgs.fenix.complete.withComponents [
+            "cargo"
+            "clippy"
+            "rust-src"
+            "rustc"
+            "rustfmt"
+            "rust-analyzer"
+          ])
+          pkgs.dotnet-sdk_8
+        ];
+        env = {
+          LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath (with pkgs; [
+            stdenv.cc.cc.lib
+            libX11
+            libXcursor
+            libxi
+            libxkbcommon
+            mesa
+            libGL
+          ]);
+        };
+      };
     };
 }

--- a/nix/deps.json
+++ b/nix/deps.json
@@ -1,0 +1,22 @@
+[
+  {
+    "pname": "Microsoft.AspNetCore.App.Ref",
+    "version": "8.0.25",
+    "hash": "sha256-DVHrrmbR3zUhUvm7ghgmcUyGJjnemJS8O4I9wPOyi6A="
+  },
+  {
+    "pname": "Microsoft.NETCore.App.Ref",
+    "version": "8.0.25",
+    "hash": "sha256-uGJMkwuuDKK1qKHcMfl+7zKD9yvE3ZFxz9o5Dk128Zw="
+  },
+  {
+    "pname": "Newtonsoft.Json",
+    "version": "13.0.3",
+    "hash": "sha256-hy/BieY4qxBWVVsDqqOPaLy1QobiIapkbrESm6v2PHc="
+  },
+  {
+    "pname": "ZstdSharp.Port",
+    "version": "0.8.1",
+    "hash": "sha256-PeQvyz3lUrK+t+n1dFtNXCLztQtAfkqUuM6mOqBZHLg="
+  }
+]

--- a/nix/retoc-build.patch
+++ b/nix/retoc-build.patch
@@ -1,0 +1,69 @@
+diff --git a/retoc-rivals/build.rs b/retoc-rivals/build.rs
+index 95c4d0d..7122789 100644
+--- a/retoc-rivals/build.rs
++++ b/retoc-rivals/build.rs
+@@ -17,6 +17,35 @@ fn main() {
+     let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR was not set"));
+     let embed_rs = out_dir.join(EMBED_RS_NAME);
+ 
++    if let Some(nix_path) = env::var_os("NIX_UASSET_API_PATH") {
++        let build_root = out_dir.join("kawaii_physics_binding");
++        let publish_dir = build_root.join("publish");
++        if publish_dir.exists() {
++            std::fs::remove_dir_all(&publish_dir)
++                .expect("failed to clean KawaiiPhysicsBinding publish dir");
++        }
++        std::fs::create_dir_all(&publish_dir)
++            .expect("failed to create KawaiiPhysicsBinding publish dir");
++
++        copy_nix_uasset_api_files(Path::new(&nix_path), &publish_dir);
++
++        let target_os = env::var("CARGO_CFG_TARGET_OS").expect("missing CARGO_CFG_TARGET_OS");
++        let binding_executable_name = binding_executable_name(&target_os);
++
++        let publish_files = collect_publish_files(&publish_dir);
++        let binding_stamp = binding_stamp(&publish_dir, &publish_files);
++
++        write_embed_file(
++            &embed_rs,
++            &publish_dir,
++            &publish_files,
++            &binding_stamp,
++            false,
++            binding_executable_name,
++        );
++        return;
++    }
++
+     if env::var_os("RETOC_SKIP_KAWAII_BINDING_BUILD").is_some() {
+         write_empty_embed_file(&embed_rs);
+         println!(
+@@ -469,3 +498,28 @@ pub static KAWAII_BINDING_FILES: &[(&str, &[u8])] = &[];
+         )
+     });
+ }
++
++fn copy_nix_uasset_api_files(nix_path: &Path, publish_dir: &Path) {
++    fn scan_and_copy(src: &Path, dest: &Path) -> std::io::Result<()> {
++        if src.is_dir() {
++            for entry in std::fs::read_dir(src)? {
++                let entry = entry?;
++                let path = entry.path();
++                let file_name = path.file_name().unwrap();
++                if path.is_dir() {
++                    scan_and_copy(&path, dest)?;
++                } else if path.is_file() {
++                    let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
++                    if ext == "dll" || ext == "json" || ext == "exe" || path.file_name().unwrap() == "KawaiiPhysicsBinding" {
++                        std::fs::copy(&path, dest.join(file_name))?;
++                    }
++                }
++            }
++        }
++        Ok(())
++    }
++
++    if let Err(err) = scan_and_copy(nix_path, publish_dir) {
++        panic!("failed to copy precompiled UAssetAPI files from {}: {err}", nix_path.display());
++    }
++}

--- a/repak-gui/src/main.rs
+++ b/repak-gui/src/main.rs
@@ -506,11 +506,11 @@ fn main() {
         custom_panic(info.into());
     }));
 
-    let exe_path = std::env::current_exe().expect("Failed to get executable path");
-    let log_path = exe_path
-        .parent()
-        .expect("Failed to get executable directory")
-        .join("latest.log");
+    let log_dir = dirs::config_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("repak_manager");
+    std::fs::create_dir_all(&log_dir).ok();
+    let log_path = log_dir.join("latest.log");
     let _log_guard = init_tracing(&log_path);
 
     info!(


### PR DESCRIPTION
this does successfully build on nix, but uhm, i really dont like the way i fix this

1. first thing first ive updated submodules (seems to need manual update often, pita)
2. i have to modify build.rs to make it not build UAssets if NIX_UASSET_API_PATH is set (and copy the files that is compiled from nix build UAssets) (this can just be a patch because its only use on nixos system)
3. (i dont really like this one), i have to edit how logs work to make it atleast launch, i havent test much but ```std::env::current_exe().expect("Failed to get executable path")``` would return nix store path which is read only

i wanted an opinion on the log_dir modification if you wanna keep the current implementation or go with this one, i am pretty sure that there is also current_exe usage in other place too